### PR TITLE
Update Arg.version to match current release (1.1)

### DIFF
--- a/src/arg.js
+++ b/src/arg.js
@@ -39,7 +39,7 @@
     var Arg = function(){
       return Arg.get.apply(global, arguments);
     };
-    Arg.version = "1.0.1";
+    Arg.version = "1.1.0";
 
     /**
      * Parses the arg string into an Arg.Arg object.


### PR DESCRIPTION
Just noticed the Arg.version was out of sync with the current release. No big deal.
