### PR TITLE
Remove the Arg._all memo from Arg.all().

### DIFF
--- a/src/arg.js
+++ b/src/arg.js
@@ -229,8 +229,7 @@
      * Gets all parameters from the current URL.
      */
     Arg.all = function(){
-      var merged = Arg.parse(Arg.querystring() + "&" + Arg.hashstring());
-      return merged;
+      return Arg.parse(Arg.querystring() + "&" + Arg.hashstring());
     };
 
     /**
@@ -245,14 +244,14 @@
      * Gets the query string parameters from the current URL.
      */
     Arg.query = function(){
-      return Arg._query ? Arg._query : Arg._query = Arg.parse(Arg.querystring());
+      return Arg.parse(Arg.querystring());
     };
 
     /**
      * Gets the hash string parameters from the current URL.
      */
     Arg.hash = function(){
-      return Arg._hash ? Arg._hash : Arg._hash = Arg.parse(Arg.hashstring());
+      return Arg.parse(Arg.hashstring());
     };
 
     /**

--- a/src/arg.js
+++ b/src/arg.js
@@ -230,7 +230,7 @@
      */
     Arg.all = function(){
       var merged = Arg.parse(Arg.querystring() + "&" + Arg.hashstring());
-      return Arg._all ? Arg._all : Arg._all = merged;
+      return merged;
     };
 
     /**

--- a/test/spec/arg.js
+++ b/test/spec/arg.js
@@ -81,18 +81,12 @@ describe("Arg", function(){
     expect(args["number"]).toEqual(27);
     expect(args["state"]).toEqual("CO");
 
-    expect(Arg._query).toEqual(args);
-
-    Arg._query = {
-      "name": "Mat",
-      "number": 30
-    };
-    args = Arg.query();
-
-    expect(args["name"]).toEqual("Mat");
-    expect(args["number"]).toEqual(30);
-
-
+    // check to make sure there's nothing extra hiding in the
+    // query map
+    for (var i in args) {
+      expect(TestArgString).toContain(i);
+      expect(TestArgString).toContain(args[i]);
+    }
   });
 
   it("should be able to get the POJO from the querystring via hash()", function(){
@@ -104,16 +98,12 @@ describe("Arg", function(){
     expect(args["number"]).toEqual(27);
     expect(args["state"]).toEqual("CO");
 
-    expect(Arg._hash).toEqual(args);
-
-    Arg._hash = {
-      "name": "Mat",
-      "number": 30
-    };
-    args = Arg.hash()
-
-    expect(args["name"]).toEqual("Mat");
-    expect(args["number"]).toEqual(30);
+    // check to make sure there's nothing extra hiding in the
+    // hash map
+    for (var i in args) {
+      expect(TestArgString).toContain(i);
+      expect(TestArgString).toContain(args[i]);
+    }
 
   });
 
@@ -127,17 +117,6 @@ describe("Arg", function(){
     expect(args["number"]).toEqual(30);
     expect(args["eggs"]).toEqual(true);
     expect(args["state"]).toEqual("CO");
-
-    expect(Arg._all).toEqual(args);
-
-    Arg._all = {
-      "name": "Mat",
-      "number": 30
-    };
-    args = Arg.all();
-
-    expect(args["name"]).toEqual("Mat");
-    expect(args["number"]).toEqual(30);
 
     // check to make sure there's nothing extra hiding in the
     // all map


### PR DESCRIPTION
Is there a reason that Arg.all() creates a memo?

It doesn't save any computation because all of the work is done before the memo variable is checked on subsequent calls to all() and it breaks all() in cases where the history API is used to manipulate the URL after an initial call to all().

If any additional changes are necessary, let me know.