### PR TITLE
Add AMD support.

### DIFF
--- a/src/arg.js
+++ b/src/arg.js
@@ -321,9 +321,16 @@
 
   };
 
-  /** @namespace
-   * Arg is the root namespace for all arg.js functionality.
-   */
-  global.Arg = MakeArg();
+  if (typeof define === 'function' && define.amd) {
+    /* AMD support */
+    define(function(){
+      return MakeArg();
+    });
+  } else {
+    /** @namespace
+     * Arg is the root namespace for all arg.js functionality.
+     */
+    global.Arg = MakeArg();
+  }
 
 })(window);


### PR DESCRIPTION
It would be nice if arg.js could be specified as a module dependency and used as a variable when using requirejs, without touching the window global or using a shim. Returning the result of MakeArg as the result of the define call makes this possible, as per typical amd usage.