### PR TITLE
Resolves #35. Fix for 'Invalid calling object' error in IE: ensure we…

### DIFF
--- a/src/arg.js
+++ b/src/arg.js
@@ -90,7 +90,7 @@
       };
 
       // selector could be a number if we're at a numerical index leaf in which case selector.search is not valid
-      if (typeof selector == 'string' || toString.call(selector) == '[object String]') {
+      if (typeof selector == 'string' || Object.prototype.toString.call(selector) == '[object String]') {
         selectorBreak = selector.search(/[\.\[]/);
       }
 


### PR DESCRIPTION
Think it's this simple. We just need to ensure we're using the toString method from Object, not Window.

Tested on IE 9, 10, 11, and Edge 14.
